### PR TITLE
set default images for posts & users; remove images from seed

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,7 +3,9 @@ class Post < ActiveRecord::Base
   # Markdown
   #before_save { MarkdownWriter.update_html(self) }
 
-  has_attached_file :image, styles: { small: "64x64", med: "300x300", large: "500x500" }
+  has_attached_file :image,
+                    styles: { small: "64x64", med: "300x300", large: "500x500" },
+                    :default_url => 'test.png'
 
   # Validations
   validates :title, presence: true, length: { maximum: 100 }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,8 +17,7 @@ u.save!
     password: "Password1",
     password_confirmation: "Password1",
     first_name: "user",
-    last_name: "\##{i}",
-      image: open('http://i.imgur.com/vDo0IT9.png')
+    last_name: "\##{i}"
   )
   # u.skip_confirmation!
   u.save!
@@ -36,8 +35,7 @@ u.save!
       measurement: 'in',
       weight_in_pounds: rand(22),
       price: (rand(1000000)) * (0.01),
-      quantity: rand(33),
-      image: open('http://i.imgur.com/vDo0IT9.png')
+      quantity: rand(33)
     )
     p.save!
     print i, "..."


### PR DESCRIPTION
set up default assets for posts & user profile images; removed images from posts & users in the seed file (improves performance); gallery does not properly show default images (because the posts have no attached images), not worth fixing if gallery is going to be removed